### PR TITLE
Small textual fixes: OpenLayers version and publish date of v3.10.2

### DIFF
--- a/docsrc/index.rst
+++ b/docsrc/index.rst
@@ -52,7 +52,7 @@ Make your maps
     :width: 400 px
     :alt: Map viewer
 
-The interactive map viewer based on `OpenLayers 3 <http://openlayers.org/>`_
+The interactive map viewer based on `OpenLayers <http://openlayers.org/>`_
 provides access to OGC services (WMS, WMTS) and standards (KML, OWS). Connected
 to the catalog, users can easily find new services, layers and even dynamic maps
 to combine them together. User maps can be annotated and printed and shared

--- a/docsrc/news.rst
+++ b/docsrc/news.rst
@@ -6,7 +6,7 @@ News
 GeoNetwork opensource v3.10.2 released
 ------------------------------------------------
 
-Date: 7 April February 2020
+Date: 7 April 2020
 
 We're pleased to announce the new minor release 3.10.2 of GeoNetwork opensource.
 Check the `changelog </manuals/trunk/en/overview/change-log/version-3.10.2.html>`_ and proceed to :doc:`downloads` and enjoy!


### PR DESCRIPTION
Small textual fixes: 
- OpenLayers version: removed the OL 3 version in the name
- fix publish date of v3.10.2