### PR TITLE
Update geOrchestra link in downloads documentation

### DIFF
--- a/docsrc/downloads.rst
+++ b/docsrc/downloads.rst
@@ -170,7 +170,7 @@ Third-party distributions
 
 Some contributors release alternative distributions build with GeoNetwork opensource. For example:
 
- * `geOrchestra <https://packages.georchestra.org>`__
+ * `geOrchestra <https://www.georchestra.org>`__
  * `GeoCat Find <https://www.geocat.com/find>`__
  * `GeoCat Live (SaaS) <https://www.geocat.com/live>`__
 


### PR DESCRIPTION
packages.georchestra.org is a placeholder to download geOrchestra artifacts, but the web page being served there is generally not as up-to-date as the main geOrchestra website.

It makes more sense to link to the main site instead of packages.georchestra.org in our (geOrchestra community) opinion.